### PR TITLE
Error handling

### DIFF
--- a/src/app/(auth)/login/error.tsx
+++ b/src/app/(auth)/login/error.tsx
@@ -1,0 +1,15 @@
+'use client'; // next.js directive
+
+// Error pages are automatically handled by next.js
+// we get 2 properties - error and reset, a function that can be used to redo the request
+const error = ({ error, reset }: { error: Error; reset: () => void }) => {
+  return (
+    <div>
+      <h1>Error</h1>
+      <p>{error.message}</p>
+      <button onClick={reset}>Try again</button>
+    </div>
+  );
+};
+
+export default error;

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,11 +2,19 @@
 // Meaning it won't show up in the route path
 // Useful for organization
 import axios from 'axios';
-
+import { AuthRequiredError } from '@/lib/exceptions';
+const session = null;
 // server components can be async
 // this is useful for fetching data from an api
 // we can use `await` at the top level of the component
 const Login = async () => {
+  // Instead of throwing this error
+  // We can create one special exception or error
+  // That will always be thrown when there's an auth error, for example
+  // if (!session) throw new Error('Unauthorized');
+  // lib/exceptions.ts
+  if (!session) throw new AuthRequiredError();
+
   const { data } = await axios.get(
     'https://jsonplaceholder.typicode.com/todos/1'
   );

--- a/src/lib/exceptions.ts
+++ b/src/lib/exceptions.ts
@@ -1,0 +1,6 @@
+export class AuthRequiredError extends Error {
+  constructor(message = 'Auth is required to access this resource') {
+    super(message);
+    this.name = 'AuthRequiredError';
+  }
+}


### PR DESCRIPTION
With AppRouter we can handle errors elegantly, and allow for the user to be part of possibly solving the problem:

- Like `loading.tsx`, include `error.tsx` in the "page" directory, and/or have an `error.tsx` at the root to catch all errors 
- `errors.tsx` is automatically handled by Next and we get a couple of useful things right away - the `error` and `reset` - a function to redo the last action, reset the page in some way. This is useful for re-running an API request. 
- We can create error classes that get picked up and handled - not necessarily a Next thing, but integrated well